### PR TITLE
docs: improve base model tablename docstring

### DIFF
--- a/activemodel/base_model.py
+++ b/activemodel/base_model.py
@@ -152,15 +152,15 @@ class BaseModel(SQLModel):
     @declared_attr
     def __tablename__(cls) -> str:
         """
-        Automatically generates the table name for the model by converting the class name from camel case to snake case.
-        This is the recommended format for table names:
+        Automatically generates the table name for the model by converting the model's class name from camel case to snake case.
+        This is the recommended text case style for table names:
 
         https://wiki.postgresql.org/wiki/Don%27t_Do_This#Don.27t_use_upper_case_table_or_column_names
 
-        By default, the class is lower cased which makes it harder to read.
+        By default, the model's class name is lower cased which makes it harder to read.
 
-        Many snake_case libraries struggle with snake case for names like LLMCache, which is why we are using a more
-        complicated implementation from pydash.
+        Also, many text case conversion libraries struggle handling words like "LLMCache", this is why we are using
+        a more precise library which processes such acronyms: [`textcase`](https://pypi.org/project/textcase/).
 
         https://stackoverflow.com/questions/1175208/elegant-python-function-to-convert-camelcase-to-snake-case
         """


### PR DESCRIPTION
This PR improved the `BaseModel.__tablename__` docstring to clarify that the model's class name is converted from camel case to snake case using the [`textcase`](https://pypi.org/project/textcase/) library (in the previous version there was a mention of [`pydash`](https://pypi.org/project/pydash/), although it is not actually used right now). In addition, this PR slightly improves the wording used in the docstring.

---

Also, note that a camel case string typically starts with a lowercase letter (e.g., "myModel"), while PascalCase starts with an uppercase letter (e.g., "MyModel"): https://en.wikipedia.org/wiki/Camel_case. So maybe it's worth updating mentions of camelCase to PascalCase in [some places](https://github.com/iloveitaly/activemodel/blob/12a5e1db9be741f12db174d5a25f6c2eee61a446/CHANGELOG.md?plain=1#L194) to avoid ambiguity.