### PR TITLE
fix: correctly serialize lists of Pydantic models using `mode=json`

### DIFF
--- a/activemodel/session_manager.py
+++ b/activemodel/session_manager.py
@@ -33,7 +33,7 @@ def _serialize_pydantic_model(model: BaseModel | list[BaseModel] | None) -> str 
         # not everything in a list is a pydantic model
         def dump_if_model(m):
             if isinstance(m, BaseModel):
-                return m.model_dump()
+                return m.model_dump(mode="json")
             return m
 
         return json.dumps([dump_if_model(m) for m in model])

--- a/tests/pydantic_json/pydantic_json_test.py
+++ b/tests/pydantic_json/pydantic_json_test.py
@@ -1,18 +1,21 @@
+from datetime import datetime
+
 from pydantic import BaseModel as PydanticBaseModel
 from sqlalchemy.dialects.postgresql import JSONB
 from sqlalchemy.orm.base import instance_state
 from sqlmodel import Field, Session
+from typeid import TypeID
 
 from activemodel import BaseModel
 from activemodel.mixins import PydanticJSONMixin, TypeIDPrimaryKey
 from activemodel.session_manager import global_session
 from tests.models import ExampleRecord
-from typeid import TypeID
 
 
 class NestedPayload(PydanticBaseModel):
     external_id: str
     is_enabled: bool = False
+    enabled_at: datetime | None = None
 
 
 class RecordWithPayloads(BaseModel, PydanticJSONMixin, table=True):
@@ -152,3 +155,31 @@ def test_sibling_save_preserves_scalar_pydantic_model(create_and_wipe_database):
 
         assert isinstance(record.primary_payload, NestedPayload)
         assert record.primary_payload.external_id == "primary_123"
+
+
+def test_saves_and_loads_pydantic_models_with_datetime(create_and_wipe_database):
+    # save() will throw an error about an object of type datetime not being JSON serializable
+    # if the Pydantic model is serialized to a dict without using Pydantic's `mode=json` option,
+    # which converts datetimes to ISO strings. See the custom serializer in SessionManager for details.
+    record = RecordWithPayloads(
+        payloads=[
+            NestedPayload(
+                external_id="payload_123",
+                is_enabled=True,
+                enabled_at=datetime(2024, 1, 1, 12, 0, 0),
+            )
+        ],
+        primary_payload=NestedPayload(
+            external_id="primary_123",
+            is_enabled=True,
+            enabled_at=datetime(2024, 1, 2, 12, 0, 0),
+        ),
+    ).save()
+
+    fresh_record = RecordWithPayloads.get(record.id)
+
+    assert fresh_record is not None
+    assert isinstance(fresh_record.payloads[0], NestedPayload)
+    assert fresh_record.payloads[0].enabled_at == datetime(2024, 1, 1, 12, 0, 0)
+    assert isinstance(fresh_record.primary_payload, NestedPayload)
+    assert fresh_record.primary_payload.enabled_at == datetime(2024, 1, 2, 12, 0, 0)


### PR DESCRIPTION
Hi @iloveitaly, I was running into a bug where trying to save a DB model with a field that is a list of Pydantic models with a `datetime` property, results in an error about `datetime` objects not being serializable. After a lot of debugging, I found that the bug originates from the SessionManager using `m.model_dump()` instead of `m.model_dump(mode="json")`.

This PR fixes that bug and adds a test case to prevent regressions.

Until this is merged and released, users can manually work around this by copying the `_serialize_pydantic_model` function from ActiveModel's source code, adding `mode="json"`, and using `activemodel.init(..., engine_options={"json_serializer": _serialize_pydantic_json}`).

Commits:
- fix: lists of Pydantic models now correctly serialize using mode=json on model_dump, fixing support for datetime fields on Pydantic models and other fields that json.dumps doesn't handle, but Pydantic does