### PR TITLE
Improve docs tech architecture (Sphinx toolchain)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,6 +26,10 @@ jobs:
       - name: Build
         run: just docs-build
 
+      # sphinx-llm runs a nested markdown Sphinx build after HTML. That subprocess can
+      # fail (e.g. a broken intersphinx inventory) while the primary HTML build still
+      # reports success and exits 0 — leaving llms.txt / llms-full.txt unpublished.
+      # Assert the artifacts exist so CI catches that silent miss.
       - name: Verify LLM artifacts
         run: |
           test -f docs/_build/html/llms.txt

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,6 +3,7 @@ name: docs
 on:
   push:
     branches: [master]
+  pull_request:
 
 permissions:
   contents: write
@@ -11,22 +12,32 @@ env:
   MISE_ENV: ci
 
 jobs:
-  build-and-deploy:
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      
+
       - uses: jdx/mise-action@v4
       - uses: iloveitaly/github-action-direnv-load-and-mask@master
 
       - name: Install dependencies
-        run: uv sync --all-extras
+        run: uv sync --group docs
 
       - name: Build
         run: just docs-build
 
+      - name: Verify LLM artifacts
+        run: |
+          test -f docs/_build/html/llms.txt
+          test -f docs/_build/html/llms-full.txt
+          head -n 5 docs/_build/html/llms.txt
+
+      - name: Run examples
+        run: just examples
+
       - name: Deploy to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: JamesIves/github-pages-deploy-action@v4
         with:
           folder: docs/_build/html
-          branch: gh-pages # This creates/updates a branch for the website
+          branch: gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -137,6 +137,8 @@ dmypy.json
 tmp/
 
 examples/*.db
+database.db
+*.db
 
 /tests/migrations/versions
 

--- a/Justfile
+++ b/Justfile
@@ -21,9 +21,9 @@ docker_down:
 test:
     uv run pytest -v
 
-# Build documentation
+# Build documentation (docs deps live in the uv `docs` group, not a package extra)
 docs-build:
-    uv run sphinx-build -b html docs docs/_build/html
+    uv run --group docs sphinx-build -b html docs docs/_build/html
 
 # Run the types generation script
 generate-types:
@@ -31,7 +31,11 @@ generate-types:
 
 # Serve documentation with live reload
 docs-serve:
-    uv run sphinx-autobuild docs docs/_build/html --port 8000 --watch activemodel
+    uv run --group docs sphinx-autobuild docs docs/_build/html --port 8000 --watch activemodel
+
+# Run canonical examples/ scripts (kept in sync with docs via literalinclude)
+examples:
+    uv run python examples/whenever_typeid_and_sqlite.py
 
 # python linting checks
 [script]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -6,18 +6,16 @@ copyright = f"{datetime.now().year}, Michael Bianco"
 author = "Michael Bianco"
 
 # 2. Extensions
+# AutoAPI is the sole API generator (AST-based; avoids importing patched modules).
+# autodoc/napoleon/autodoc-typehints/paramlinks are intentionally omitted.
 extensions = [
     "myst_parser",  # Enable Markdown
     "sphinx_design",  # UI Components (Grids/Cards)
     "sphinx_copybutton",  # Code copy button
-    "sphinx.ext.autodoc",  # API doc generation
-    "sphinx.ext.napoleon",  # Support for Google-style docstrings
     "sphinx.ext.viewcode",  # View source code
     "sphinx.ext.intersphinx",  # Link to external docs
     "autoapi.extension",  # Auto-generate API reference
-    "sphinx_autodoc_typehints",  # Clean up type hints
-    "sphinx_paramlinks",  # Direct links to parameters
-    "sphinx_llm.txt",  # LLM-friendly documentation
+    "sphinx_llm.txt",  # LLM-friendly documentation (llms.txt / llms-full.txt)
 ]
 
 # Configure AutoAPI
@@ -25,24 +23,30 @@ autoapi_dirs = ["../activemodel"]
 autoapi_type = "python"
 autoapi_ignore = [
     "*/logger.py",
+    "*/patches/*",
 ]
 autoapi_options = [
     "members",
     "undoc-members",
     "show-inheritance",
     "show-module-summary",
-    "special-members",
-    "imported-members",
 ]
-autoapi_keep_files = True
+autoapi_keep_files = False
 
 # Intersphinx configuration
+# sqlmodel.tiangolo.com currently serves an empty objects.inv (breaks the build)
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
-    "pydantic": ("https://docs.pydantic.dev/latest/", None),
-    "sqlmodel": ("https://sqlmodel.tiangolo.com/", None),
+    "pydantic": (
+        "https://docs.pydantic.dev/latest/",
+        "https://pydantic.dev/docs/validation/latest/objects.inv",
+    ),
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
 }
+intersphinx_timeout = 10
+
+# sphinx-llm runs a nested markdown build; keep it sequential for clearer errors
+llms_txt_build_parallel = False
 
 # 3. Markdown Support Configuration
 source_suffix = {
@@ -79,5 +83,14 @@ html_theme_options = {
         {"title": "Getting Started", "url": "getting-started"},
         {"title": "API Reference", "url": "autoapi/index"},
         {"title": "Changelog", "url": "changelog"},
+        {"title": "llms.txt", "url": "llms.txt", "resource": True},
     ],
 }
+
+# 5. sphinx-llm: publish machine-readable docs alongside HTML
+llms_txt_enabled = True
+llms_txt_full_build = True
+llms_txt_description = (
+    "ActiveModel: SQLModel with ActiveRecord-style developer ergonomics. "
+    "ORM helpers, TypeID/whenever integrations, pytest fixtures, and JSONB mutation tracking."
+)

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,6 +1,21 @@
 # Examples
 
-This section provides practical examples of how to use `activemodel` in your projects, demonstrating common patterns for structured data, lifecycle management, testing, and complex schema definitions.
+Canonical runnable examples live under [`examples/`](https://github.com/iloveitaly/activemodel/tree/master/examples) and are included here with `literalinclude` so the docs stay in sync with code that CI executes (`just examples`).
+
+## whenever + TypeID + SQLite
+
+End-to-end script: init SQLite, define a TypeID-backed model with a `whenever.PlainDateTime` field, create tables, save, and round-trip.
+
+```{literalinclude} ../examples/whenever_typeid_and_sqlite.py
+:language: python
+```
+
+Run it locally:
+
+```bash
+just examples
+# or: uv run python examples/whenever_typeid_and_sqlite.py
+```
 
 ## Advanced Field Types and Configuration
 
@@ -49,6 +64,7 @@ class Product(BaseModel, table=True):
     # Define max lengths and index the column
     status: str = Field(default="active", max_length=100, index=True)
 ```
+
 ## Structured JSON with Pydantic Models
 
 Using the `PydanticJSONMixin`, you can store complex Pydantic models or lists of models in PostgreSQL `JSONB` columns. The mixin handles serialization and deserialization automatically.

--- a/docs/whenever.md
+++ b/docs/whenever.md
@@ -14,6 +14,8 @@
 
 Import and annotate fields with the bare `whenever` type. The SQLAlchemy column type is resolved automatically via the `get_sqlalchemy_type` patch that `activemodel` applies on import.
 
+A full runnable SQLite example (TypeID + `PlainDateTime`) lives in {doc}`examples` and is included from `examples/whenever_typeid_and_sqlite.py`.
+
 ```python
 from whenever import Instant, PlainDateTime, ZonedDateTime
 from activemodel import BaseModel

--- a/examples/whenever_typeid_and_sqlite.py
+++ b/examples/whenever_typeid_and_sqlite.py
@@ -3,7 +3,7 @@ from whenever import Instant, PlainDateTime
 
 import activemodel
 from activemodel import BaseModel
-from activemodel.mixins.typeid import TypeIDMixin
+from activemodel.mixins import TypeIDPrimaryKey
 from activemodel.session_manager import get_engine
 
 # Although this looks like it's an absolute path, it is translated into a relative path based on the source location of this file
@@ -12,12 +12,11 @@ activemodel.init("sqlite:///database.db")
 
 class User(
     BaseModel,
-    # you can use a different pk type, but why would you?
-    # put this mixin last otherwise `id` will not be the first column in the DB
-    TypeIDMixin("user"),
     # wire this model into the DB, without this alembic will not generate a migration
     table=True,
 ):
+    # you can use a different pk type, but why would you?
+    id: str = TypeIDPrimaryKey("user")
     # PlainDateTime matches SQLite behavior: no timezone support
     booked_date: PlainDateTime
 
@@ -25,7 +24,8 @@ class User(
 # This magic command enables you to avoid the need to run or manage migrations and just magically creates all the tables in the local database
 SQLModel.metadata.create_all(get_engine())
 
-now_in_sys_time = Instant.now().to_system_tz().to_plain()
+# SQLite/stdlib datetimes are microsecond-precision; truncate nanoseconds for a clean round-trip
+now_in_sys_time = PlainDateTime(Instant.now().to_system_tz().to_plain().to_stdlib())
 
 user = User(booked_date=now_in_sys_time).save()
 fresh_user = User.one(user.id)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,20 +13,6 @@ authors = [{ name = "Michael Bianco", email = "iloveitaly@gmail.com" }]
 keywords = ["sqlmodel", "orm", "activerecord", "activemodel", "sqlalchemy"]
 urls = { "Repository" = "https://github.com/iloveitaly/activemodel", "Documentation" = "https://iloveitaly.github.io/activemodel/" }
 
-[project.optional-dependencies]
-docs = [
-    "sphinx>=7.1.2",
-    "shibuya",
-    "myst-parser>=2.0.0",
-    "sphinx-design>=0.5.0",
-    "sphinx-copybutton>=0.5.2",
-    "sphinx-autobuild",
-    "sphinx-autoapi",
-    "sphinx-autodoc-typehints",
-    "sphinx-paramlinks",
-    "sphinx-llm",
-]
-
 [project.entry-points.pytest11]
 activemodel = "activemodel.pytest.plugin"
 
@@ -61,6 +47,17 @@ dev = [
     "pytest-cov>=7.0.0",
     "covdefaults>=2.3.0",
     "factory-boy>=3.3.3",
+]
+# Sphinx toolchain for local/CI docs builds — not a published package extra
+docs = [
+    "sphinx>=7.1.2",
+    "shibuya",
+    "myst-parser>=2.0.0",
+    "sphinx-design>=0.5.0",
+    "sphinx-copybutton>=0.5.2",
+    "sphinx-autobuild",
+    "sphinx-autoapi",
+    "sphinx-llm",
 ]
 
 [tool.pyright]

--- a/tests/examples_test.py
+++ b/tests/examples_test.py
@@ -1,0 +1,23 @@
+"""Ensure canonical examples/ scripts stay runnable."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+EXAMPLES_DIR = Path(__file__).resolve().parents[1] / "examples"
+
+
+def test_whenever_typeid_and_sqlite_example(tmp_path):
+    """Run the documented whenever + TypeID + SQLite example in a clean process."""
+    # Subprocess avoids the SessionManager singleton already configured by conftest.
+    result = subprocess.run(
+        [sys.executable, str(EXAMPLES_DIR / "whenever_typeid_and_sqlite.py")],
+        cwd=tmp_path,
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode == 0, result.stderr or result.stdout
+    assert (tmp_path / "database.db").exists()

--- a/uv.lock
+++ b/uv.lock
@@ -16,20 +16,6 @@ dependencies = [
     { name = "whenever" },
 ]
 
-[package.optional-dependencies]
-docs = [
-    { name = "myst-parser" },
-    { name = "shibuya" },
-    { name = "sphinx" },
-    { name = "sphinx-autoapi" },
-    { name = "sphinx-autobuild" },
-    { name = "sphinx-autodoc-typehints" },
-    { name = "sphinx-copybutton" },
-    { name = "sphinx-design" },
-    { name = "sphinx-llm" },
-    { name = "sphinx-paramlinks" },
-]
-
 [package.dev-dependencies]
 debugging-extras = [
     { name = "pytest-watcher" },
@@ -50,24 +36,23 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
 ]
+docs = [
+    { name = "myst-parser" },
+    { name = "shibuya" },
+    { name = "sphinx" },
+    { name = "sphinx-autoapi" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-copybutton" },
+    { name = "sphinx-design" },
+    { name = "sphinx-llm" },
+]
 
 [package.metadata]
 requires-dist = [
-    { name = "myst-parser", marker = "extra == 'docs'", specifier = ">=2.0.0" },
-    { name = "shibuya", marker = "extra == 'docs'" },
-    { name = "sphinx", marker = "extra == 'docs'", specifier = ">=7.1.2" },
-    { name = "sphinx-autoapi", marker = "extra == 'docs'" },
-    { name = "sphinx-autobuild", marker = "extra == 'docs'" },
-    { name = "sphinx-autodoc-typehints", marker = "extra == 'docs'" },
-    { name = "sphinx-copybutton", marker = "extra == 'docs'", specifier = ">=0.5.2" },
-    { name = "sphinx-design", marker = "extra == 'docs'", specifier = ">=0.5.0" },
-    { name = "sphinx-llm", marker = "extra == 'docs'" },
-    { name = "sphinx-paramlinks", marker = "extra == 'docs'" },
     { name = "sqlmodel", specifier = "==0.0.39" },
     { name = "typeid-python", specifier = "==0.3.10" },
     { name = "whenever", specifier = ">=0.10.0" },
 ]
-provides-extras = ["docs"]
 
 [package.metadata.requires-dev]
 debugging-extras = [{ name = "pytest-watcher", specifier = ">=0.4.3" }]
@@ -86,6 +71,16 @@ dev = [
     { name = "pytest", specifier = ">=8.3.4" },
     { name = "pytest-cov", specifier = ">=7.0.0" },
     { name = "ruff", specifier = ">=0.15.0" },
+]
+docs = [
+    { name = "myst-parser", specifier = ">=2.0.0" },
+    { name = "shibuya" },
+    { name = "sphinx", specifier = ">=7.1.2" },
+    { name = "sphinx-autoapi" },
+    { name = "sphinx-autobuild" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2" },
+    { name = "sphinx-design", specifier = ">=0.5.0" },
+    { name = "sphinx-llm" },
 ]
 
 [[package]]
@@ -1540,18 +1535,6 @@ wheels = [
 ]
 
 [[package]]
-name = "sphinx-autodoc-typehints"
-version = "3.12.1"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/de/ae/8ad5e79a0f7beac5e5810b2a8d0a1c6c63c795ba265a81970070abf15f32/sphinx_autodoc_typehints-3.12.1.tar.gz", hash = "sha256:4bbf6f6b907586d3b2a3ae2b23e0f86be939f19a7449e917d304df57ff9674d1", size = 84421, upload-time = "2026-07-03T13:52:09.056Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/2a/a2/d5964523f0c98e39ef608a09f3de23032aa32fbe3e98a262e2112c39f985/sphinx_autodoc_typehints-3.12.1-py3-none-any.whl", hash = "sha256:932472c9cc160e6a0dc34eca13d3d6a9823ed6e6dc505d7c12f6963c983cf8f6", size = 42950, upload-time = "2026-07-03T13:52:07.696Z" },
-]
-
-[[package]]
 name = "sphinx-copybutton"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1601,16 +1584,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/a0/58/0b7b9a7d071140b37
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c2/8f/9fecf3d081d5cd49eff83a17b9fef50ed741e6223ab3bb906de4ab0068f9/sphinx_markdown_builder-0.6.10-py3-none-any.whl", hash = "sha256:16d86738b9ac69fcbc86e373c31c6402c30af1fa8d98d0f62cc5f38bfe5fc26e", size = 16700, upload-time = "2026-03-11T10:56:56.135Z" },
 ]
-
-[[package]]
-name = "sphinx-paramlinks"
-version = "0.6.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "docutils" },
-    { name = "sphinx" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/ae/21/62d3a58ff7bd02bbb9245a63d1f0d2e0455522a11a78951d16088569fca8/sphinx-paramlinks-0.6.0.tar.gz", hash = "sha256:746a0816860aa3fff5d8d746efcbec4deead421f152687411db1d613d29f915e", size = 12363, upload-time = "2023-08-11T16:09:28.604Z" }
 
 [[package]]
 name = "sphinxcontrib-applehelp"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Implements the docs tech-architecture plan: keep Sphinx, tighten the toolchain, and make docs/examples CI-verifiable.

### Changes
- **Deps**: move Sphinx stack from `[project.optional-dependencies].docs` to a uv `[dependency-groups] docs` (not a PyPI extra); install with `uv sync --group docs` / `uv run --group docs`
- **Extensions**: AutoAPI-only API generation; drop autodoc / napoleon / autodoc-typehints / paramlinks; ignore `patches/`; drop `special-members` / `imported-members`
- **Examples**: `literalinclude` of `examples/whenever_typeid_and_sqlite.py` in docs; `just examples`; pytest subprocess coverage in `tests/examples_test.py`
- **CI**: docs workflow runs on PRs (build + examples + llms artifact checks); deploy to `gh-pages` only on `master` push
- **LLM artifacts**: configure `sphinx-llm` (`llms_txt_description`, sequential markdown build); publish `llms.txt` / `llms-full.txt`; link from Shibuya nav
- **Intersphinx**: remove broken empty SQLModel inventory; point Pydantic at the current inventory URL

### Verified locally
- `just docs-build` succeeds and emits `docs/_build/html/llms.txt`, `llms-full.txt`, and AutoAPI pages
- `just examples` and `tests/examples_test.py` pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ae91494-f29a-4440-9628-36ca3fd79ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ae91494-f29a-4440-9628-36ca3fd79ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

