### PR TITLE
Remove llms.txt from docs top navigation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,6 @@ html_theme_options = {
         {"title": "Getting Started", "url": "getting-started"},
         {"title": "API Reference", "url": "autoapi/index"},
         {"title": "Changelog", "url": "changelog"},
-        {"title": "llms.txt", "url": "llms.txt", "resource": True},
     ],
 }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Follow-up to #136: drop `llms.txt` from the Shibuya top nav.

The file is still built and published at `/llms.txt` (and CI still verifies it exists). It just shouldn't appear as a human-facing menu item.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7ae91494-f29a-4440-9628-36ca3fd79ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7ae91494-f29a-4440-9628-36ca3fd79ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

