### PR TITLE
build(deps): require whenever >=0.10.3

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -219,7 +219,7 @@ class UserFactory(ActiveModelFactory[User]):
     # Using Use() to execute a function dynamically for each build
     # Combining with `whenever` for timezone-aware datetimes
     last_active_at = Use(
-        lambda: Instant.now().to_system_tz().add(days=-5).py_datetime()
+        lambda: Instant.now().to_system_tz().add(days=-5).to_stdlib()
     )
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ requires-python = ">=3.13"
 dependencies = [
     "sqlmodel==0.0.39",
     "typeid-python==0.3.10",
-    "whenever>=0.10.0",
+    "whenever>=0.10.3",
 ]
 authors = [{ name = "Michael Bianco", email = "iloveitaly@gmail.com" }]
 keywords = ["sqlmodel", "orm", "activerecord", "activemodel", "sqlalchemy"]

--- a/uv.lock
+++ b/uv.lock
@@ -51,7 +51,7 @@ docs = [
 requires-dist = [
     { name = "sqlmodel", specifier = "==0.0.39" },
     { name = "typeid-python", specifier = "==0.3.10" },
-    { name = "whenever", specifier = ">=0.10.0" },
+    { name = "whenever", specifier = ">=0.10.3" },
 ]
 
 [package.metadata.requires-dev]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Bump the published `whenever` dependency floor from `>=0.10.0` to `>=0.10.3` (current latest on PyPI).
- Refresh the factory docs example to use `to_stdlib()` instead of the deprecated `py_datetime()`.

## Test plan
- [x] `uv lock` / `uv sync` resolves `whenever==0.10.3`
- [x] Local pytest against Postgres: **249 passed**
- [x] CI matrix-test on Python 3.12 / 3.13 / 3.14: all green
- [x] Docs build + lint jobs: green
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-15d4ad35-19b3-4a41-a6ec-b48c2781eb86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-15d4ad35-19b3-4a41-a6ec-b48c2781eb86"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

